### PR TITLE
Sanitize parsing of kwargs to handle complex dbnames

### DIFF
--- a/pgdb.py
+++ b/pgdb.py
@@ -1662,10 +1662,9 @@ def connect(dsn=None,
             value = str(value)
             if not value or ' ' in value:
                 value = "'%s'" % (value.replace(
-                    "'", "\\'").replace('\\', '\\\\'),)
+                    '\\', '\\\\').replace("'", "\\'"))
             dbname.append('%s=%s' % (kw, value))
         dbname = ' '.join(dbname)
-
     # open the connection
     cnx = _connect(dbname, dbhost, dbport, dbopt, dbuser, dbpasswd)
     return Connection(cnx)

--- a/tests/test_dbapi20.py
+++ b/tests/test_dbapi20.py
@@ -80,7 +80,7 @@ class test_PyGreSQL(dbapi20.DatabaseAPI20Test):
         self.assertEqual(pgdb.__version__, v)
 
     def test_connect_kwargs(self):
-        application_name = 'PyGreSQL DB API 2.0 Test'
+        application_name = 'PyGreSQL DB API 2.0 Test with\' quote and \\\\backslash'
         self.connect_kw_args['application_name'] = application_name
         con = self._connect()
         cur = con.cursor()


### PR DESCRIPTION
When kwargs was made available in pgdb.connect(), rather than appending
the argument values to the "dbopt" paramater passed to _connect(), the
kwargs were joined to dbname, which has it's own parameter in _connect()
already.

Due to this design, a dbname containing a space caused problems, with
the dbname parameters becoming something like:

`dbname=dbname with space -c option=optionvalue`

This caused an exception, pg.InternalError if a database name like
`funny copy"db'with\\quotes` was used:

`missing "=" after "with\\\\quotes'" in connection info string`

But only if kwargs were specified - otherwise, the dbname was passed
safely to _connect() as a plain string without being modified.

This commit addressed this problem by not touching the specified dbname.
A dbname can be be added safely as the database arg of pgdb.connect(),
or as part of the dsn string, and opts from the dsn string or kwargs
will be added appropriately as well, utilizing the dbopt args in
_connect() rather than overloading the dbname.

Co-authored-by: Tyler Ramer <tramer@pivotal.io>
Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>