### PR TITLE
Remove upper bounds on PG server version

### DIFF
--- a/tests/test_classic_connection.py
+++ b/tests/test_classic_connection.py
@@ -175,7 +175,6 @@ class TestConnectObject(unittest.TestCase):
         server_version = self.connection.server_version
         self.assertIsInstance(server_version, int)
         self.assertGreaterEqual(server_version, 100000)
-        self.assertLess(server_version, 170000)
 
     def test_attribute_socket(self):
         socket = self.connection.socket

--- a/tests/test_classic_dbwrapper.py
+++ b/tests/test_classic_dbwrapper.py
@@ -169,7 +169,6 @@ class TestDBClassBasic(unittest.TestCase):
         server_version = self.db.server_version
         self.assertIsInstance(server_version, int)
         self.assertGreaterEqual(server_version, 100000)
-        self.assertLess(server_version, 170000)
         self.assertEqual(server_version, self.db.db.server_version)
 
     def test_attribute_socket(self):

--- a/tests/test_classic_functions.py
+++ b/tests/test_classic_functions.py
@@ -125,7 +125,6 @@ class TestHasConnect(unittest.TestCase):
         v = pg.get_pqlib_version()
         self.assertIsInstance(v, int)
         self.assertGreater(v, 100000)
-        self.assertLess(v, 170000)
 
 
 class TestParseArray(unittest.TestCase):


### PR DESCRIPTION
Restricting PyGreSQL tests to just work with server versions less than a fixed number prevents upgrading PostgreSQL, even when all other tests work fine.