### PR TITLE
inserttable() to use str(datetime) rather than repr()

### DIFF
--- a/ext/pgconn.c
+++ b/ext/pgconn.c
@@ -12,6 +12,9 @@
 #include "pginternal.h"
 #include "pgmodule.h"
 
+/* Needs to be after Python.h */
+#include "datetime.h"
+
 /* Deallocate connection object. */
 static void
 conn_dealloc(connObject *self)
@@ -789,6 +792,11 @@ conn_inserttable(connObject *self, PyObject *args, PyObject *kwds)
 
     encoding = PQclientEncoding(self->cnx);
 
+    PyDateTime_IMPORT;
+    if (PyErr_Occurred()) {
+        return NULL; /* pass the error */
+    }
+
     /* pre-allocate some memory for the query buffer */
     if (!init_char_buffer(&buffer, 4096)) {
         Py_DECREF(iter_row);
@@ -984,6 +992,14 @@ conn_inserttable(connObject *self, PyObject *args, PyObject *kwds)
                 }
             }
             else if (PyLong_Check(item)) {
+                PyObject *s = PyObject_Str(item);
+                const char *t = PyUnicode_AsUTF8(s);
+
+                ext_char_buffer_s(&buffer, t);
+                Py_DECREF(s);
+            }
+            else if (PyDate_Check(item) || PyDateTime_Check(item) ||
+                     PyTime_Check(item) || PyDelta_Check(item)) {
                 PyObject *s = PyObject_Str(item);
                 const char *t = PyUnicode_AsUTF8(s);
 

--- a/tests/test_classic_connection.py
+++ b/tests/test_classic_connection.py
@@ -11,6 +11,7 @@ These tests need a database to test against.
 
 from __future__ import annotations
 
+import datetime as dt
 import os
 import threading
 import time
@@ -1896,6 +1897,12 @@ class TestInserttable(unittest.TestCase):
         data = [()] * 10
         self.c.inserttable('test', data, [])
         self.assertEqual(self.get_back(), [])
+
+    def test_inserttable_datetime_adapt(self):
+        data = [(dt.date(1999,1,2), dt.time(11,12,13))]
+        self.c.inserttable('test', data, ['dt', 'ti'])
+        self.assertEqual([i[4:6] for i in self.get_back()],
+                         [tuple(str(j) for j in i) for i in data])
 
     def test_inserttable_only_one_column(self):
         data: list[tuple] = [(42,)] * 50


### PR DESCRIPTION
Previously, datetime fields needed to be str()'ified by the caller.